### PR TITLE
chore(main): initialize LangSmith tracing and set up logging

### DIFF
--- a/freestream/main.py
+++ b/freestream/main.py
@@ -15,6 +15,12 @@ from langchain.chains import ConversationalRetrievalChain
 from langchain_community.vectorstores import FAISS
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 
+# Initialize LangSmith tracing
+os.environ["LANGCHAIN_TRACING_V2"] = "true"
+os.environ["LANGCHAIN_PROJECT"] = "FreeStream-v1"
+os.environ["LANGCHAIN_ENDPOINT"] = st.secrets.LANGCHAIN.LANGCHAIN_ENDPOINT
+os.environ["LANGCHAIN_API_KEY"] = st.secrets.LANGCHAIN.LANGCHAIN_API_KEY
+
 # Set up logging
 logging.basicConfig(level=logging.INFO, stream=sys.stdout)
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Initialize LangSmith tracing for FreeStream-v1 project and set up logging in main.py. Set environment variables for LangSmith tracing and logging configuration.

This commit initializes LangSmith tracing for the FreeStream-v1 project by setting environment variables and sets up logging in the main.py file.