### PR TITLE
chore(git): Update .gitignore and pyproject.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .streamlit/secrets.toml
+.codegeneration
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 
 name = "FreeStream"
-version = "3.1.0"
+version = "3.1.1"
 description = "An effort to give easy access to generative AI."
 authors = ["Daethyra <109057945+Daethyra@users.noreply.github.com>"]
 readme = "README.md"


### PR DESCRIPTION
Updated .gitignore to ignore .codegeneration and incremented the version in pyproject.toml from 3.1.0 to 3.1.1.