### PR TITLE
chore(pages): update image upscaler limitations

### DIFF
--- a/freestream/pages/2_🖼️_Image_Upscaler.py
+++ b/freestream/pages/2_🖼️_Image_Upscaler.py
@@ -35,7 +35,7 @@ st.markdown(
     
     **Limitations**:
     
-    * Images with a width *or* height greater than 512 will be downsampled by 3/20ths. This limitation will be removed once Real-ESRGAN is implemented.
+    * Images with a width *or* height greater than 128 will be downsampled by 3/20ths. This limitation will be removed once Real-ESRGAN is implemented.
     * The current upscaler problematically generates new content around the edge of the image, especially on the right side.
     
     As with all FreeStream pages, this one's purpose is merely to show you the possibilities without having to sign up or program anything manually. 


### PR DESCRIPTION
Changed the limitation for images with a width or height greater than 128 to be downsampled by 3/20ths instead of 512. This change is in preparation for the implementation of Real-ESRGAN and aims to provide a more accurate representation of the upscaling process.