### PR TITLE
fix(utils): adjust image size limit

### DIFF
--- a/freestream/pages/utils/utility_funcs.py
+++ b/freestream/pages/utils/utility_funcs.py
@@ -252,7 +252,7 @@ def image_upscaler(image: str) -> Image:
 
     # If the image is greater than 300 in either dimension, then
     # stop the application
-    if img.width > 1024 or img.height > 1024:
+    if img.width > 300 or img.height > 300:
         st.warning(
             "Image is too large. Please upload an image with a width and height less than 1024."
         )


### PR DESCRIPTION
Changed the image size limit in the utility function to 300x300 pixels to prevent oversized images from being processed, ensuring smoother application performance.