### PR TITLE
fix(pages): corrected tool model assignment

### DIFF
--- a/freestream/pages/3_🛠️_InfoNexus.py
+++ b/freestream/pages/3_🛠️_InfoNexus.py
@@ -62,7 +62,7 @@ model = ChatOpenAI(
 
 # Set a model for tools
 # Requires an 'LLM' not 'Chat Model'
-toollm = OpenAI(
+toollm = ChatOpenAI(
     model="gpt-3.5-turbo",
     temperature=temperature_slider,
     openai_api_key=st.secrets.OPENAI.openai_api_key,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 
 name = "FreeStream"
-version = "4.1.0"
+version = "4.1.1"
 description = "Free AI Assistants."
 authors = ["Daethyra <109057945+Daethyra@users.noreply.github.com>"]
 readme = "README.md"


### PR DESCRIPTION
Changed the tool model assignment in the InfoNexus page from "OpenAI" to "ChatOpenAI" to ensure compatibility with the "v1/chat/completions" endpoint

Previously, calls to the `llm-math` tool, which requires NumExpr, would throw an error:

```PowerShell
openai.NotFoundError: Error code: 404 - {'error': {'message': 'This is a chat model and not supported in the v1/completions endpoint. Did you mean to use v1/chat/completions?', 'type': 'invalid_request_error', 'param': 'model', 'code': None}}
```