### PR TITLE
chore(freestream): enable GPT4 and Opus

### DIFF
--- a/freestream/pages/1_🤖_RAGbot.py
+++ b/freestream/pages/1_🤖_RAGbot.py
@@ -75,14 +75,14 @@ model_names = {
         max_tokens=4096,  # Set the maximum number of tokens for the model's responses
         max_retries=1,  # Set the maximum number of retries for the model
     ),
-    # "GPT-4 Turbo": ChatOpenAI(
-    #     model="gpt-4-0125-preview",
-    #     openai_api_key=st.secrets.OPENAI.openai_api_key,
-    #     temperature=temperature_slider,
-    #     streaming=True,
-    #     max_tokens=4096,
-    #     max_retries=1,
-    # ),
+    "GPT-4 Turbo": ChatOpenAI(
+        model="gpt-4-0125-preview",
+        openai_api_key=st.secrets.OPENAI.openai_api_key,
+        temperature=temperature_slider,
+        streaming=True,
+        max_tokens=4096,
+        max_retries=1,
+    ),
     "Claude: Haiku": ChatAnthropic(
         model="claude-3-haiku-20240307",
         anthropic_api_key=st.secrets.ANTHROPIC.anthropic_api_key,
@@ -90,13 +90,13 @@ model_names = {
         streaming=True,
         max_tokens=4096,
     ),
-    # "Claude: Sonnet": ChatAnthropic(
-    #     model="claude-3-sonnet-20240229",
-    #     anthropic_api_key=st.secrets.ANTHROPIC.anthropic_api_key,
-    #     temperature=temperature_slider,
-    #     streaming=True,
-    #     max_tokens=4096,
-    # ),
+    "Claude: Sonnet": ChatAnthropic(
+        model="claude-3-sonnet-20240229",
+        anthropic_api_key=st.secrets.ANTHROPIC.anthropic_api_key,
+        temperature=temperature_slider,
+        streaming=True,
+        max_tokens=4096,
+    ),
     "Claude: Opus": ChatAnthropic(
         model="claude-3-opus-20240229",
         anthropic_api_key=st.secrets.ANTHROPIC.anthropic_api_key,

--- a/freestream/pages/2_💬_Curie.py
+++ b/freestream/pages/2_💬_Curie.py
@@ -79,14 +79,14 @@ model_names = {
         max_tokens=4096,  # Set the maximum number of tokens for the model's responses
         max_retries=1,  # Set the maximum number of retries for the model
     ),
-    # "GPT-4 Turbo": ChatOpenAI(
-    #    model="gpt-4-0125-preview",
-    #    openai_api_key=st.secrets.OPENAI.openai_api_key,
-    #    temperature=temperature_slider,
-    #    streaming=True,
-    #    max_tokens=4096,
-    #    max_retries=1,
-    # ),
+    "GPT-4 Turbo": ChatOpenAI(
+       model="gpt-4-0125-preview",
+       openai_api_key=st.secrets.OPENAI.openai_api_key,
+       temperature=temperature_slider,
+       streaming=True,
+       max_tokens=4096,
+       max_retries=1,
+    ),
     "Claude: Haiku": ChatAnthropic(
         model="claude-3-haiku-20240307",
         anthropic_api_key=st.secrets.ANTHROPIC.anthropic_api_key,
@@ -101,13 +101,13 @@ model_names = {
         streaming=True,
         max_tokens=4096,
     ),
-    # "Claude: Opus": ChatAnthropic(
-    #     model="claude-3-opus-20240229",
-    #     anthropic_api_key=st.secrets.ANTHROPIC.anthropic_api_key,
-    #     temperature=temperature_slider,
-    #     streaming=True,
-    #     max_tokens=4096,
-    # ),
+    "Claude: Opus": ChatAnthropic(
+        model="claude-3-opus-20240229",
+        anthropic_api_key=st.secrets.ANTHROPIC.anthropic_api_key,
+        temperature=temperature_slider,
+        streaming=True,
+        max_tokens=4096,
+    ),
 }
 
 # Create a dropdown menu for selecting a chat model


### PR DESCRIPTION
Updated the chat model configurations for "GPT-4 Turbo", "Claude: Sonnet", and "Claude: Opus" in the freestream application. Removed commented-out code and aligned the code structure for consistency. No functional changes were made, only code organization.