### PR TITLE
refactor(model names): updated model names in Curie and RAGbot scripts

### DIFF
--- a/freestream/pages/1_💬_Curie.py
+++ b/freestream/pages/1_💬_Curie.py
@@ -58,15 +58,15 @@ if st.sidebar.button("Clear message history", use_container_width=True):
 # Create a dictionary with keys to chat model classes
 model_names = {
     "GPT-3.5 Turbo": ChatOpenAI(  # Define a dictionary entry for the "ChatOpenAI GPT-3.5 Turbo" model
-        model="gpt-3.5-turbo-0125",  # Set the OpenAI model name
+        model="gpt-3.5-turbo",  # Set the OpenAI model name
         openai_api_key=st.secrets.OPENAI.openai_api_key,  # Set the OpenAI API key from the Streamlit secrets manager
         temperature=temperature_slider,  # Set the temperature for the model's responses using the sidebar slider
         streaming=True,  # Enable streaming responses for the model
         max_tokens=4096,  # Set the maximum number of tokens for the model's responses
         max_retries=1,  # Set the maximum number of retries for the model
     ),
-    "GPT-4 Turbo": ChatOpenAI(
-       model="gpt-4-0125-preview",
+    "GPT-4o": ChatOpenAI(
+       model="gpt-4o",
        openai_api_key=st.secrets.OPENAI.openai_api_key,
        temperature=temperature_slider,
        streaming=True,

--- a/freestream/pages/2_🤖_RAGbot.py
+++ b/freestream/pages/2_🤖_RAGbot.py
@@ -69,15 +69,15 @@ if st.sidebar.button("Clear message history", use_container_width=True):
 # Create a dictionary with keys to chat model classes
 model_names = {
     "GPT-3.5 Turbo": ChatOpenAI(  # Define a dictionary entry for the "ChatOpenAI GPT-3.5 Turbo" model
-        model="gpt-3.5-turbo-0125",  # Set the OpenAI model name
+        model="gpt-3.5-turbo",  # Set the OpenAI model name
         openai_api_key=st.secrets.OPENAI.openai_api_key,  # Set the OpenAI API key from the Streamlit secrets manager
         temperature=temperature_slider,  # Set the temperature for the model's responses using the sidebar slider
         streaming=True,  # Enable streaming responses for the model
         max_tokens=4096,  # Set the maximum number of tokens for the model's responses
         max_retries=1,  # Set the maximum number of retries for the model
     ),
-    "GPT-4 Turbo": ChatOpenAI(
-        model="gpt-4-0125-preview",
+    "GPT-4o": ChatOpenAI(
+        model="gpt-4o",
         openai_api_key=st.secrets.OPENAI.openai_api_key,
         temperature=temperature_slider,
         streaming=True,


### PR DESCRIPTION
Updated the model names in the Curie and RAGbot scripts to reflect changes in the OpenAI model naming convention. Renamed "GPT-4 Turbo" to "GPT-4o" and adjusted the model version for "GPT-3.5 Turbo" to remove the version number suffix.