### PR TITLE
Split `model_names` dictionary and dynamically load chat models

### DIFF
--- a/freestream/pages/1_💬_Curie.py
+++ b/freestream/pages/1_💬_Curie.py
@@ -15,7 +15,7 @@ from pages import (PrintRetrievalHandler, RetrieveDocuments, StreamHandler,
 
 # Initialize LangSmith tracing
 os.environ["LANGCHAIN_TRACING_V2"] = "true"
-os.environ["LANGCHAIN_PROJECT"] = "FreeStream-v4.0.0"
+os.environ["LANGCHAIN_PROJECT"] = "FreeStream"
 os.environ["LANGCHAIN_ENDPOINT"] = st.secrets.LANGCHAIN.LANGCHAIN_ENDPOINT
 os.environ["LANGCHAIN_API_KEY"] = st.secrets.LANGCHAIN.LANGCHAIN_API_KEY
 
@@ -40,13 +40,6 @@ if "anthropic_api_key" in st.secrets.ANTHROPIC:
     anthropic_api_key = st.secrets.ANTHROPIC.anthropic_api_key
 else:
     anthropic_api_key = st.sidebar.text_input("Anthropic API Key", type="password")
-
-# Ensure at least one model is accessible
-if not "openai_api_key" in st.secrets and not "openai_api_key" in st.secrets.OPENAI and not "anthropic_api_key" in st.secrets and not "anthropic_api_key" in st.secrets.ANTHROPIC:
-    st.error(
-        body="""You must set at least one API key before you may continue.""",
-        icon="🚨",
-    )
 
 # Add temperature header
 temperature_header = st.sidebar.markdown(
@@ -78,7 +71,7 @@ if st.sidebar.button("Clear message history", use_container_width=True):
 openai_models = {
     "GPT-3.5 Turbo": ChatOpenAI(  # Define a dictionary entry for the "ChatOpenAI GPT-3.5 Turbo" model
         model="gpt-3.5-turbo",  # Set the OpenAI model name
-        openai_api_key=st.secrets.OPENAI.openai_api_key,  # Set the OpenAI API key from the Streamlit secrets manager
+        openai_api_key=openai_api_key,  # Set the OpenAI API key from the Streamlit secrets manager
         temperature=temperature_slider,  # Set the temperature for the model's responses using the sidebar slider
         streaming=True,  # Enable streaming responses for the model
         max_tokens=4096,  # Set the maximum number of tokens for the model's responses
@@ -86,7 +79,7 @@ openai_models = {
     ),
     "GPT-4o": ChatOpenAI(
        model="gpt-4o",
-       openai_api_key=st.secrets.OPENAI.openai_api_key,
+       openai_api_key=openai_api_key,
        temperature=temperature_slider,
        streaming=True,
        max_tokens=4096,
@@ -97,21 +90,21 @@ openai_models = {
 anthropic_models = {
     "Claude: Haiku": ChatAnthropic(
         model="claude-3-haiku-20240307",
-        anthropic_api_key=st.secrets.ANTHROPIC.anthropic_api_key,
+        anthropic_api_key=anthropic_api_key,
         temperature=temperature_slider,
         streaming=True,
         max_tokens=4096,
     ),
     "Claude: Sonnet": ChatAnthropic(
         model="claude-3-sonnet-20240229",
-        anthropic_api_key=st.secrets.ANTHROPIC.anthropic_api_key,
+        anthropic_api_key=anthropic_api_key,
         temperature=temperature_slider,
         streaming=True,
         max_tokens=4096,
     ),
     "Claude: Opus": ChatAnthropic(
         model="claude-3-opus-20240229",
-        anthropic_api_key=st.secrets.ANTHROPIC.anthropic_api_key,
+        anthropic_api_key=anthropic_api_key,
         temperature=temperature_slider,
         streaming=True,
         max_tokens=4096,
@@ -122,9 +115,9 @@ anthropic_models = {
 model_names = {}
 
 # Update model master dictionary based on present API keys
-if "openai_api_key" in st.secrets or "openai_api_key" in st.secrets.OPENAI:
+if openai_api_key:
     model_names.update(openai_models)
-if "anthropic_api_key" in st.secrets or "anthropic_api_key" in st.secrets.ANTHROPIC:
+if anthropic_api_key:
     model_names.update(anthropic_models)
 
 # Create a dropdown menu for selecting a chat model

--- a/freestream/pages/2_🤖_RAGbot.py
+++ b/freestream/pages/2_🤖_RAGbot.py
@@ -13,7 +13,7 @@ from pages import (PrintRetrievalHandler, RetrieveDocuments, StreamHandler,
 
 # Initialize LangSmith tracing
 os.environ["LANGCHAIN_TRACING_V2"] = "true"
-os.environ["LANGCHAIN_PROJECT"] = "FreeStream-v4.0.0"
+os.environ["LANGCHAIN_PROJECT"] = "FreeStream"
 os.environ["LANGCHAIN_ENDPOINT"] = st.secrets.LANGCHAIN.LANGCHAIN_ENDPOINT
 os.environ["LANGCHAIN_API_KEY"] = st.secrets.LANGCHAIN.LANGCHAIN_API_KEY
 
@@ -40,12 +40,6 @@ if "anthropic_api_key" in st.secrets.ANTHROPIC:
 else:
     anthropic_api_key = st.sidebar.text_input("Anthropic API Key", type="password")
 
-# Ensure at least one model is accessible
-if not "openai_api_key" in st.secrets and not "openai_api_key" in st.secrets.OPENAI and not "anthropic_api_key" in st.secrets and not "anthropic_api_key" in st.secrets.ANTHROPIC:
-    st.error(
-        body="""You must set at least one API key before you may continue.""",
-        icon="🚨",
-    )
 
 # Add file-upload button
 uploaded_files = st.sidebar.file_uploader(
@@ -90,7 +84,7 @@ if st.sidebar.button("Clear message history", use_container_width=True):
 openai_models = {
     "GPT-3.5 Turbo": ChatOpenAI(  # Define a dictionary entry for the "ChatOpenAI GPT-3.5 Turbo" model
         model="gpt-3.5-turbo",  # Set the OpenAI model name
-        openai_api_key=st.secrets.OPENAI.openai_api_key,  # Set the OpenAI API key from the Streamlit secrets manager
+        openai_api_key=openai_api_key,  # Set the OpenAI API key from the Streamlit secrets manager
         temperature=temperature_slider,  # Set the temperature for the model's responses using the sidebar slider
         streaming=True,  # Enable streaming responses for the model
         max_tokens=4096,  # Set the maximum number of tokens for the model's responses
@@ -98,7 +92,7 @@ openai_models = {
     ),
     "GPT-4o": ChatOpenAI(
        model="gpt-4o",
-       openai_api_key=st.secrets.OPENAI.openai_api_key,
+       openai_api_key=openai_api_key,
        temperature=temperature_slider,
        streaming=True,
        max_tokens=4096,
@@ -109,21 +103,21 @@ openai_models = {
 anthropic_models = {
     "Claude: Haiku": ChatAnthropic(
         model="claude-3-haiku-20240307",
-        anthropic_api_key=st.secrets.ANTHROPIC.anthropic_api_key,
+        anthropic_api_key=anthropic_api_key,
         temperature=temperature_slider,
         streaming=True,
         max_tokens=4096,
     ),
     "Claude: Sonnet": ChatAnthropic(
         model="claude-3-sonnet-20240229",
-        anthropic_api_key=st.secrets.ANTHROPIC.anthropic_api_key,
+        anthropic_api_key=anthropic_api_key,
         temperature=temperature_slider,
         streaming=True,
         max_tokens=4096,
     ),
     "Claude: Opus": ChatAnthropic(
         model="claude-3-opus-20240229",
-        anthropic_api_key=st.secrets.ANTHROPIC.anthropic_api_key,
+        anthropic_api_key=anthropic_api_key,
         temperature=temperature_slider,
         streaming=True,
         max_tokens=4096,
@@ -134,9 +128,9 @@ anthropic_models = {
 model_names = {}
 
 # Update model master dictionary based on present API keys
-if "openai_api_key" in st.secrets or "openai_api_key" in st.secrets.OPENAI:
+if openai_api_key:
     model_names.update(openai_models)
-if "anthropic_api_key" in st.secrets or "anthropic_api_key" in st.secrets.ANTHROPIC:
+if anthropic_api_key:
     model_names.update(anthropic_models)
 
 # Create a dropdown menu for selecting a chat model

--- a/freestream/pages/2_🤖_RAGbot.py
+++ b/freestream/pages/2_🤖_RAGbot.py
@@ -27,6 +27,26 @@ st.markdown(footer, unsafe_allow_html=True)
 
 # Add sidebar
 st.sidebar.subheader("__User Panel__")
+
+# Get an OpenAI API Key before continuing
+if "openai_api_key" in st.secrets.OPENAI:
+    openai_api_key = st.secrets.OPENAI.openai_api_key
+else:
+    openai_api_key = st.sidebar.text_input("OpenAI API Key", type="password")
+
+# Get an Anthropic API Key before continuing
+if "anthropic_api_key" in st.secrets.ANTHROPIC:
+    anthropic_api_key = st.secrets.ANTHROPIC.anthropic_api_key
+else:
+    anthropic_api_key = st.sidebar.text_input("Anthropic API Key", type="password")
+
+# Ensure at least one model is accessible
+if not "openai_api_key" in st.secrets and not "openai_api_key" in st.secrets.OPENAI and not "anthropic_api_key" in st.secrets and not "anthropic_api_key" in st.secrets.ANTHROPIC:
+    st.error(
+        body="""You must set at least one API key before you may continue.""",
+        icon="🚨",
+    )
+
 # Add file-upload button
 uploaded_files = st.sidebar.file_uploader(
     label="Upload a PDF or text file",
@@ -66,8 +86,8 @@ memory = ConversationBufferMemory(
 if st.sidebar.button("Clear message history", use_container_width=True):
     msgs.clear()
 
-# Create a dictionary with keys to chat model classes
-model_names = {
+# Create dictionaries with keys to chat model classes
+openai_models = {
     "GPT-3.5 Turbo": ChatOpenAI(  # Define a dictionary entry for the "ChatOpenAI GPT-3.5 Turbo" model
         model="gpt-3.5-turbo",  # Set the OpenAI model name
         openai_api_key=st.secrets.OPENAI.openai_api_key,  # Set the OpenAI API key from the Streamlit secrets manager
@@ -77,13 +97,16 @@ model_names = {
         max_retries=1,  # Set the maximum number of retries for the model
     ),
     "GPT-4o": ChatOpenAI(
-        model="gpt-4o",
-        openai_api_key=st.secrets.OPENAI.openai_api_key,
-        temperature=temperature_slider,
-        streaming=True,
-        max_tokens=4096,
-        max_retries=1,
-    ),
+       model="gpt-4o",
+       openai_api_key=st.secrets.OPENAI.openai_api_key,
+       temperature=temperature_slider,
+       streaming=True,
+       max_tokens=4096,
+       max_retries=1,
+    )
+}
+
+anthropic_models = {
     "Claude: Haiku": ChatAnthropic(
         model="claude-3-haiku-20240307",
         anthropic_api_key=st.secrets.ANTHROPIC.anthropic_api_key,
@@ -106,6 +129,15 @@ model_names = {
         max_tokens=4096,
     ),
 }
+
+# Master dictionary
+model_names = {}
+
+# Update model master dictionary based on present API keys
+if "openai_api_key" in st.secrets or "openai_api_key" in st.secrets.OPENAI:
+    model_names.update(openai_models)
+if "anthropic_api_key" in st.secrets or "anthropic_api_key" in st.secrets.ANTHROPIC:
+    model_names.update(anthropic_models)
 
 # Create a dropdown menu for selecting a chat model
 selected_model = st.selectbox(

--- a/poetry.lock
+++ b/poetry.lock
@@ -864,18 +864,18 @@ numpy = "*"
 
 [[package]]
 name = "filelock"
-version = "3.15.1"
+version = "3.15.3"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "filelock-3.15.1-py3-none-any.whl", hash = "sha256:71b3102950e91dfc1bb4209b64be4dc8854f40e5f534428d8684f953ac847fac"},
-    {file = "filelock-3.15.1.tar.gz", hash = "sha256:58a2549afdf9e02e10720eaa4d4470f56386d7a6f72edd7d0596337af8ed7ad8"},
+    {file = "filelock-3.15.3-py3-none-any.whl", hash = "sha256:0151273e5b5d6cf753a61ec83b3a9b7d8821c39ae9af9d7ecf2f9e2f17404103"},
+    {file = "filelock-3.15.3.tar.gz", hash = "sha256:e1199bf5194a2277273dacd50269f0d87d0682088a3c561c15674ea9005d8635"},
 ]
 
 [package.extras]
 docs = ["furo (>=2023.9.10)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.25.2)"]
-testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8.0.1)", "pytest (>=7.4.3)", "pytest-asyncio (>=0.21)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)", "pytest-timeout (>=2.2)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8.0.1)", "pytest (>=7.4.3)", "pytest-asyncio (>=0.21)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)", "pytest-timeout (>=2.2)", "virtualenv (>=20.26.2)"]
 typing = ["typing-extensions (>=4.8)"]
 
 [[package]]
@@ -1915,13 +1915,13 @@ six = "*"
 
 [[package]]
 name = "langsmith"
-version = "0.1.80"
+version = "0.1.81"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 optional = false
 python-versions = "<4.0,>=3.8.1"
 files = [
-    {file = "langsmith-0.1.80-py3-none-any.whl", hash = "sha256:951fc29576b52afd8378d41f6db343090fea863e3620f0ca97e83b221f93c94d"},
-    {file = "langsmith-0.1.80.tar.gz", hash = "sha256:a29b1dde27612308beee424f1388ad844c8e7e375bf2ac8bdf4da174013f279d"},
+    {file = "langsmith-0.1.81-py3-none-any.whl", hash = "sha256:3251d823225eef23ee541980b9d9e506367eabbb7f985a086b5d09e8f78ba7e9"},
+    {file = "langsmith-0.1.81.tar.gz", hash = "sha256:585ef3a2251380bd2843a664c9a28da4a7d28432e3ee8bcebf291ffb8e1f0af0"},
 ]
 
 [package.dependencies]
@@ -2808,13 +2808,13 @@ sympy = "*"
 
 [[package]]
 name = "openai"
-version = "1.34.0"
+version = "1.35.1"
 description = "The official Python library for the openai API"
 optional = false
 python-versions = ">=3.7.1"
 files = [
-    {file = "openai-1.34.0-py3-none-any.whl", hash = "sha256:018623c2f795424044675c6230fa3bfbf98d9e0aab45d8fd116f2efb2cfb6b7e"},
-    {file = "openai-1.34.0.tar.gz", hash = "sha256:95c8e2da4acd6958e626186957d656597613587195abd0fb2527566a93e76770"},
+    {file = "openai-1.35.1-py3-none-any.whl", hash = "sha256:53ef8935cf916dc7ece67fee5a8a09fc4db5aadf4d6e95b5b7f767f3c4432e4d"},
+    {file = "openai-1.35.1.tar.gz", hash = "sha256:d85973adc2f4fbb11ba20bfd948e3340b8352f6b8a02f1fa1c387c8eefac8d9d"},
 ]
 
 [package.dependencies]
@@ -3357,20 +3357,20 @@ tests = ["pytest (>=5.4.1)", "pytest-cov (>=2.8.1)", "pytest-mypy (>=0.8.0)", "p
 
 [[package]]
 name = "proto-plus"
-version = "1.23.0"
+version = "1.24.0"
 description = "Beautiful, Pythonic protocol buffers."
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "proto-plus-1.23.0.tar.gz", hash = "sha256:89075171ef11988b3fa157f5dbd8b9cf09d65fffee97e29ce403cd8defba19d2"},
-    {file = "proto_plus-1.23.0-py3-none-any.whl", hash = "sha256:a829c79e619e1cf632de091013a4173deed13a55f326ef84f05af6f50ff4c82c"},
+    {file = "proto-plus-1.24.0.tar.gz", hash = "sha256:30b72a5ecafe4406b0d339db35b56c4059064e69227b8c3bda7462397f966445"},
+    {file = "proto_plus-1.24.0-py3-none-any.whl", hash = "sha256:402576830425e5f6ce4c2a6702400ac79897dab0b4343821aa5188b0fab81a12"},
 ]
 
 [package.dependencies]
-protobuf = ">=3.19.0,<5.0.0dev"
+protobuf = ">=3.19.0,<6.0.0dev"
 
 [package.extras]
-testing = ["google-api-core[grpc] (>=1.31.5)"]
+testing = ["google-api-core (>=1.31.5)"]
 
 [[package]]
 name = "protobuf"
@@ -4568,18 +4568,18 @@ train = ["accelerate (>=0.20.3)", "datasets"]
 
 [[package]]
 name = "setuptools"
-version = "70.0.0"
+version = "70.1.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-70.0.0-py3-none-any.whl", hash = "sha256:54faa7f2e8d2d11bcd2c07bed282eef1046b5c080d1c32add737d7b5817b1ad4"},
-    {file = "setuptools-70.0.0.tar.gz", hash = "sha256:f211a66637b8fa059bb28183da127d4e86396c991a942b028c6650d4319c3fd0"},
+    {file = "setuptools-70.1.0-py3-none-any.whl", hash = "sha256:d9b8b771455a97c8a9f3ab3448ebe0b29b5e105f1228bba41028be116985a267"},
+    {file = "setuptools-70.1.0.tar.gz", hash = "sha256:01a1e793faa5bd89abc851fa15d0a0db26f160890c7102cd8dce643e886b47f5"},
 ]
 
 [package.extras]
 docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mypy (==1.9)", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.1)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy", "pytest-perf", "pytest-ruff (>=0.2.1)", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "jaraco.test", "mypy (==1.10.0)", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.1)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy", "pytest-perf", "pytest-ruff (>=0.3.2)", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "six"
@@ -4868,13 +4868,13 @@ blobfile = ["blobfile (>=2)"]
 
 [[package]]
 name = "timm"
-version = "1.0.3"
+version = "1.0.7"
 description = "PyTorch Image Models"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "timm-1.0.3-py3-none-any.whl", hash = "sha256:d1ec86f7765aa79fbc7491508fa6e285d38a38f10bf4fe44ba2e9c70f91f0f5b"},
-    {file = "timm-1.0.3.tar.gz", hash = "sha256:83920a7efe2cfd503b2a1257dc8808d6ff7dcd18a4b79f451c283e7d71497329"},
+    {file = "timm-1.0.7-py3-none-any.whl", hash = "sha256:942ced65b47b5ec12b8df07eb8ee929f1bb310402155b28931ab7a85ecc1cef2"},
+    {file = "timm-1.0.7.tar.gz", hash = "sha256:d1d26d906b5e188d7e7d536a6a0999568bb184f884f9a334c48d46fc6dc166c8"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 
 name = "FreeStream"
-version = "4.3.0"
+version = "4.4.0"
 description = "Template repository for building chatbots."
 authors = ["Daethyra <109057945+Daethyra@users.noreply.github.com>"]
 readme = "README.md"


### PR DESCRIPTION
- split `model_names` into two dictionaries
  - `model_names` is now a master dictionary
- update `model_names` based on the present API keys
  - ex. if an OpenAI API key is loaded via Streamlit's configuration file or manually entered in the sidebar, make all OpenAI models available in the chat model select box