### PR TITLE
fix(pages): stop process if no API key is provided

### DIFF
--- a/freestream/pages/1_💬_Curie.py
+++ b/freestream/pages/1_💬_Curie.py
@@ -41,6 +41,11 @@ if "anthropic_api_key" in st.secrets.ANTHROPIC:
 else:
     anthropic_api_key = st.sidebar.text_input("Anthropic API Key", type="password")
 
+# Stop the process if no API key is provided
+if not openai_api_key and not anthropic_api_key:
+    st.error("You must provide at least one API key, either for OpenAI or Anthropic, to continue.", icon="🚨")
+    st.stop()
+
 # Add temperature header
 temperature_header = st.sidebar.markdown(
     """

--- a/freestream/pages/2_🤖_RAGbot.py
+++ b/freestream/pages/2_🤖_RAGbot.py
@@ -40,6 +40,10 @@ if "anthropic_api_key" in st.secrets.ANTHROPIC:
 else:
     anthropic_api_key = st.sidebar.text_input("Anthropic API Key", type="password")
 
+# Stop the process if no API key is provided
+if not openai_api_key and not anthropic_api_key:
+    st.error("You must provide at least one API key, either for OpenAI or Anthropic, to continue.", icon="🚨")
+    st.stop()
 
 # Add file-upload button
 uploaded_files = st.sidebar.file_uploader(


### PR DESCRIPTION
Ensure that the process halts when neither an OpenAI nor an Anthropic API key is provided to prevent errors and guide users to input at least one valid key for seamless functionality.