### PR TITLE
chore(freestream): Add GPT-4o Mini

### DIFF
--- a/freestream/pages/1_💬_Curie.py
+++ b/freestream/pages/1_💬_Curie.py
@@ -74,8 +74,8 @@ if st.sidebar.button("Clear message history", use_container_width=True):
 
 # Create dictionaries with keys to chat model classes
 openai_models = {
-    "GPT-3.5 Turbo": ChatOpenAI(  # Define a dictionary entry for the "ChatOpenAI GPT-3.5 Turbo" model
-        model="gpt-3.5-turbo",  # Set the OpenAI model name
+    "GPT-4o Mini": ChatOpenAI(  # Define a dictionary entry for the "ChatOpenAI GPT-3.5 Turbo" model
+        model="gpt-4o-mini",  # Set the OpenAI model name
         openai_api_key=openai_api_key,  # Set the OpenAI API key from the Streamlit secrets manager
         temperature=temperature_slider,  # Set the temperature for the model's responses using the sidebar slider
         streaming=True,  # Enable streaming responses for the model

--- a/freestream/pages/2_🤖_RAGbot.py
+++ b/freestream/pages/2_🤖_RAGbot.py
@@ -86,8 +86,8 @@ if st.sidebar.button("Clear message history", use_container_width=True):
 
 # Create dictionaries with keys to chat model classes
 openai_models = {
-    "GPT-3.5 Turbo": ChatOpenAI(  # Define a dictionary entry for the "ChatOpenAI GPT-3.5 Turbo" model
-        model="gpt-3.5-turbo",  # Set the OpenAI model name
+    "GPT-4o Mini": ChatOpenAI(  # Define a dictionary entry for the "ChatOpenAI GPT-3.5 Turbo" model
+        model="gpt-4o-mini",  # Set the OpenAI model name
         openai_api_key=openai_api_key,  # Set the OpenAI API key from the Streamlit secrets manager
         temperature=temperature_slider,  # Set the temperature for the model's responses using the sidebar slider
         streaming=True,  # Enable streaming responses for the model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 
 name = "FreeStream"
-version = "4.4.1"
+version = "4.4.2"
 description = "Template repository for building chatbots."
 authors = ["Daethyra <109057945+Daethyra@users.noreply.github.com>"]
 readme = "README.md"


### PR DESCRIPTION
Updated the OpenAI model version from "GPT-3.5 Turbo" to "GPT-4o Mini" in the ChatOpenAI dictionary entries for consistency and accuracy across the project. Also incremented the project version in pyproject.toml from 4.4.1 to 4.4.2.